### PR TITLE
Fix: update like and comment count on single post

### DIFF
--- a/src/components/Like/Like.jsx
+++ b/src/components/Like/Like.jsx
@@ -16,6 +16,11 @@ export class Like extends Component {
     this.setState({ highlight: liked, likesCount });
   }
 
+  componentDidUpdate(prevProps) {
+    const { liked, likesCount } = this.props;
+    if (prevProps.liked !== liked) this.setState({ highlight: liked, likesCount });
+  }
+
   toggleLikeHighlight = () => {
     const { likesCount, highlight } = this.state;
     const checkLimit = () => (highlight && likesCount > 0 ? likesCount - 1 : likesCount + 1);

--- a/src/components/PostComments/PostComments.jsx
+++ b/src/components/PostComments/PostComments.jsx
@@ -18,28 +18,12 @@ export class PostComments extends Component {
 
   render() {
     const {
-      post: { likesCount },
       items,
       loading,
     } = this.props;
 
-    const commentsCount = items.length;
-
     return (
       <div className="post-comments">
-        <div className="info">
-          <span>
-            {`${commentsCount} `}
-            Comment
-            {commentsCount !== 1 ? 's' : ''}
-          </span>
-          <span>
-            {`${likesCount} `}
-            Like
-            {likesCount !== 1 ? 's' : ''}
-          </span>
-        </div>
-
         <div className="posts">
           {loading && <ContentLoader />}
 
@@ -69,9 +53,6 @@ PostComments.propTypes = {
   items: PropTypes.array.isRequired,
   loading: PropTypes.bool.isRequired,
   slug: PropTypes.string.isRequired,
-  post: PropTypes.shape({
-    likesCount: PropTypes.number.isRequired,
-  }).isRequired,
   onGetPostComments: PropTypes.func.isRequired,
 };
 

--- a/src/components/PostComponent/PostCard.jsx
+++ b/src/components/PostComponent/PostCard.jsx
@@ -95,8 +95,7 @@ export class PostCard extends Component {
 
           <div className="bottom">
             <div className="left">
-              <Like {...{ slug, likesCount, liked }} />
-
+              <Like slug={slug} likesCount={likesCount} liked={liked} />
               <div
                 className="action"
                 onClick={() => this.handlePushPost(slug)}
@@ -134,7 +133,7 @@ PostCard.propTypes = {
   createdAt: PropTypes.string.isRequired,
   liked: PropTypes.bool,
   slug: PropTypes.string.isRequired,
-  push: PropTypes.func.isRequired,
+  push: PropTypes.func,
   _setSharePostContent: PropTypes.func,
   commentsCount: PropTypes.number,
   onFetchSinglePost: PropTypes.func,
@@ -142,10 +141,11 @@ PostCard.propTypes = {
 
 PostCard.defaultProps = {
   image: null,
-  liked: false,
+  liked: null,
   _setSharePostContent: () => '',
   commentsCount: 0,
   onFetchSinglePost: () => null,
+  push: () => null,
 };
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/components/PostComponent/PostCard.jsx
+++ b/src/components/PostComponent/PostCard.jsx
@@ -36,6 +36,7 @@ export class PostCard extends Component {
       slug,
       push,
       commentsCount,
+      comments,
     } = this.props;
     return (
       <>
@@ -104,7 +105,7 @@ export class PostCard extends Component {
                 tabIndex="-1"
               >
                 <i className="far fa-comment-alt" />
-                <span className="count">{commentsCount}</span>
+                <span className="count">{comments.length || commentsCount}</span>
               </div>
             </div>
 
@@ -136,6 +137,7 @@ PostCard.propTypes = {
   push: PropTypes.func,
   _setSharePostContent: PropTypes.func,
   commentsCount: PropTypes.number,
+  comments: PropTypes.array,
   onFetchSinglePost: PropTypes.func,
 };
 
@@ -144,6 +146,7 @@ PostCard.defaultProps = {
   liked: null,
   _setSharePostContent: () => '',
   commentsCount: 0,
+  comments: [],
   onFetchSinglePost: () => null,
   push: () => null,
 };
@@ -152,4 +155,8 @@ const mapDispatchToProps = (dispatch) => ({
   _setSharePostContent: (payload) => dispatch(setSharePostContent(payload)),
 });
 
-export default connect(null, mapDispatchToProps)(PostCard);
+const mapStateToProps = ({ postComments: { items } }) => ({
+  comments: items,
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(PostCard);

--- a/src/components/SinglePost/SinglePost.jsx
+++ b/src/components/SinglePost/SinglePost.jsx
@@ -40,7 +40,7 @@ export class SinglePost extends Component {
                 <Post {...post} />
                 <hr />
                 <PostComment slug={post.slug} allowImagePicker={false} />
-                <PostComments post={post} slug={slug} />
+                <PostComments slug={slug} />
               </>
             )}
           </div>


### PR DESCRIPTION
#### What does this PR do?
Update the likeCount and Comment count on the single post page.
#### Description of Task to be completed?
- add comments on the PostCard component from redux.
- add the method componentWillUpdate in the Like component to update state (highlight) when the props change on the PostCard component.
- remove the comments count and likes count on the PostComments component
#### How should this be manually tested?
Fetch and clone the branch git fetch origin fix-like-and-comment-count-single-post && git checkout fix-like-and-comment-count-single-post
Start the server, click on a post and then like and post a comment.
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/35597858/68655657-16157080-0539-11ea-830b-eba5d69ce6b5.png)

#### Questions:
N/A